### PR TITLE
fix display version

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,6 +201,7 @@ func _main() int {
 	}
 
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return UNKNOWN
 	}
 

--- a/main.go
+++ b/main.go
@@ -178,7 +178,10 @@ func fetchMetrics(opts commandOpts, ss []*sacloud.Server) (map[string]interface{
 }
 
 func printVersion() {
-	fmt.Printf(`%s Compiler: %s %s`,
+	fmt.Printf(`%s %s
+Compiler: %s %s
+`,
+		os.Args[0],
 		version,
 		runtime.Compiler,
 		runtime.Version())
@@ -190,15 +193,15 @@ func main() {
 
 func _main() int {
 	opts := commandOpts{}
-	psr := flags.NewParser(&opts, flags.Default)
+	psr := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
 	_, err := psr.Parse()
-	if err != nil {
-		return UNKNOWN
-	}
-
 	if opts.Version {
 		printVersion()
 		return OK
+	}
+
+	if err != nil {
+		return UNKNOWN
 	}
 
 	if opts.Time < 1 {


### PR DESCRIPTION
before

```
# /usr/local/bin/sacloud-cpu-usage -v
the required flags `--prefix' and `--zone' were not specified
```

This PR

```
% ./sacloud-cpu-usage -v             
./sacloud-cpu-usage 0.0.8
Compiler: gc go1.18.4


% ./sacloud-cpu-usage -h   
Usage:
  sacloud-cpu-usage [OPTIONS]

Application Options:
      --time=           Get average CPU usage for a specified amount of time (default: 3)
      --prefix=         prefix for server names. prefix accepts more than one.
      --zone=           zone name
      --percentile-set= percentiles to dispaly (default: 99,95,90,75)
  -v, --version         Show version
      --query=          jq style query to result and display
      --env-from=       load envrionment values from this file

Help Options:
  -h, --help            Show this help message

% ./sacloud-cpu-usage -x   
unknown flag `x'

```