### PR TITLE
Fix: calculation of avg/max/min

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func fetchResources(ctx context.Context, client iaasServerAPI, opts *usage.Optio
 				if !strings.HasPrefix(r.Name, prefix) {
 					continue
 				}
-				monitors, err := fetchServerActivities(ctx, client, zone, r.ID, opts)
+				monitors, err := fetchServerActivities(ctx, client, zone, r.ID, r.GetCPU(), opts)
 				if err != nil {
 					return nil, err
 				}
@@ -117,7 +117,7 @@ func fetchResources(ctx context.Context, client iaasServerAPI, opts *usage.Optio
 	return rs, nil
 }
 
-func fetchServerActivities(ctx context.Context, client iaasServerAPI, zone string, id types.ID, opts *usage.Option) ([]usage.MonitorValue, error) {
+func fetchServerActivities(ctx context.Context, client iaasServerAPI, zone string, id types.ID, cores int, opts *usage.Option) ([]usage.MonitorValue, error) {
 	ctx, span := otel.Tracer(appName).Start(ctx, "usage.fetchServerActivities")
 	defer span.End()
 
@@ -137,7 +137,7 @@ func fetchServerActivities(ctx context.Context, client iaasServerAPI, zone strin
 
 	var results []usage.MonitorValue
 	for _, u := range usages {
-		results = append(results, usage.MonitorValue{Time: u.Time, Value: u.CPUTime})
+		results = append(results, usage.MonitorValue{Time: u.Time, Value: 100 * u.CPUTime / float64(cores)})
 	}
 	return results, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -86,7 +86,7 @@ func Test_fetchResources(t *testing.T) {
 								Values: []*iaas.MonitorCPUTimeValue{
 									{
 										Time:    time.Unix(1, 0),
-										CPUTime: 1,
+										CPUTime: 0.01,
 									},
 								},
 							},
@@ -139,15 +139,15 @@ func Test_fetchResources(t *testing.T) {
 								Values: []*iaas.MonitorCPUTimeValue{
 									{
 										Time:    time.Unix(1, 0),
-										CPUTime: 1,
+										CPUTime: 0.01,
 									},
 									{
 										Time:    time.Unix(2, 0),
-										CPUTime: 2,
+										CPUTime: 0.02,
 									},
 									{
 										Time:    time.Unix(3, 0),
-										CPUTime: 3,
+										CPUTime: 0.03,
 									},
 								},
 							},
@@ -215,7 +215,7 @@ func Test_fetchResources(t *testing.T) {
 								Values: []*iaas.MonitorCPUTimeValue{
 									{
 										Time:    time.Unix(1, 0),
-										CPUTime: 1,
+										CPUTime: 0.01,
 									},
 								},
 							},
@@ -225,7 +225,7 @@ func Test_fetchResources(t *testing.T) {
 								Values: []*iaas.MonitorCPUTimeValue{
 									{
 										Time:    time.Unix(2, 0),
-										CPUTime: 2,
+										CPUTime: 0.02,
 									},
 								},
 							},
@@ -262,7 +262,7 @@ func Test_fetchResources(t *testing.T) {
 						Monitors: []usage.MonitorValue{
 							{
 								Time:  time.Unix(2, 0),
-								Value: 2,
+								Value: 1,
 							},
 						},
 						Label: "cpu_time",
@@ -300,15 +300,15 @@ func Test_fetchResources(t *testing.T) {
 								Values: []*iaas.MonitorCPUTimeValue{
 									{
 										Time:    time.Unix(1, 0),
-										CPUTime: 1,
+										CPUTime: 0.01,
 									},
 									{
 										Time:    time.Unix(2, 0),
-										CPUTime: 2,
+										CPUTime: 0.02,
 									},
 									{
 										Time:    time.Unix(3, 0),
-										CPUTime: 3,
+										CPUTime: 0.03,
 									},
 								},
 							},
@@ -318,15 +318,15 @@ func Test_fetchResources(t *testing.T) {
 								Values: []*iaas.MonitorCPUTimeValue{
 									{
 										Time:    time.Unix(4, 0),
-										CPUTime: 4,
+										CPUTime: 0.04,
 									},
 									{
 										Time:    time.Unix(5, 0),
-										CPUTime: 5,
+										CPUTime: 0.06,
 									},
 									{
 										Time:    time.Unix(6, 0),
-										CPUTime: 6,
+										CPUTime: 0.08,
 									},
 								},
 							},
@@ -371,15 +371,15 @@ func Test_fetchResources(t *testing.T) {
 						Monitors: []usage.MonitorValue{
 							{
 								Time:  time.Unix(4, 0),
-								Value: 4,
+								Value: 2,
 							},
 							{
 								Time:  time.Unix(5, 0),
-								Value: 5,
+								Value: 3,
 							},
 							{
 								Time:  time.Unix(6, 0),
-								Value: 6,
+								Value: 4,
 							},
 						},
 						Label: "cpu_time",


### PR DESCRIPTION
#23 でsacloud-cpu-usageとsacloud-router-usageの共通部分をsacloud-usage-libに切り出した際、値の単位揃えとCPUコア数の考慮が欠落し計算結果が従来と変わってしまっていた問題を修正。

v0.0.11時点
```
$ ./sacloud-cpu-usage --zone is1b --prefix example --time 1 
{"75pt":4.25,"90pt":4.25,"95pt":4.25,"99pt":4.25,"avg":4.25,"max":4.25,"min":4.25,"servers":[{"avg":4.25,"cores":4,"monitors":[{"cpu_time":0.17,"time":"2024-01-16 10:55:00 +0900 JST"}],"name":"example","zone":"is1b"}]}
```

修正前(0bb92f477e09979fad5a2c937bda58c693545470)
```
$ ./sacloud-cpu-usage --zone is1b --prefix example --time 1 
{"75pt":0.17,"90pt":0.17,"95pt":0.17,"99pt":0.17,"avg":0.17,"max":0.17,"min":0.17,"servers":[{"avg":0.17,"cores":4,"monitors":[{"cpu_time":0.17,"time":"2024-01-16 10:55:00 +0900 JST"}],"name":"example","zone":"is1b"}]}
```

修正後
```
$ ./sacloud-cpu-usage --zone is1b --prefix example --time 1 
{"75pt":4.25,"90pt":4.25,"95pt":4.25,"99pt":4.25,"avg":4.25,"max":4.25,"min":4.25,"servers":[{"avg":4.25,"cores":4,"monitors":[{"cpu_time":4.25,"time":"2024-01-16 10:55:00 +0900 JST"}],"name":"example","zone":"is1b"}]}
```